### PR TITLE
Feat: post route for cache

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@types/express": "^4.17.13",
         "@types/lodash": "^4.14.182",
         "axios": "^0.27.2",
+        "body-parser": "^1.20.0",
         "cors": "^2.8.5",
         "dotenv": "^16.0.1",
         "express": "^4.18.1",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "@types/express": "^4.17.13",
     "@types/lodash": "^4.14.182",
     "axios": "^0.27.2",
+    "body-parser": "^1.20.0",
     "cors": "^2.8.5",
     "dotenv": "^16.0.1",
     "express": "^4.18.1",

--- a/src/app.ts
+++ b/src/app.ts
@@ -24,7 +24,7 @@ app.get("/", (req: {}, res: TypedResponse<{ response: string }>) =>
 
 //Routes
 app.use("/api/ohlcv", routerOhlcv);
-app.use("/cache", routerCache)
+app.use("/api/cache", routerCache)
 
 const port = process.env.PORT || 8080;
 

--- a/src/app.ts
+++ b/src/app.ts
@@ -5,7 +5,7 @@ import routerOhlcv from "./controllers/ohlcv";
 import { initServer } from "./utils/server";
 import cors from "cors";
 import { routerCache } from "./controllers/cache";
-
+const bodyParser = require('body-parser')
 //initialize server, accepts no args
 
 const app = initServer();
@@ -15,7 +15,8 @@ app.use(
     origin: "*",
   })
 );
-
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json())
 //Index route: format for consistent implementation of interface and type.
 //TODO: Interfaces for response shape, abstract response validation from interface for each endpoint.
 app.get("/", (req: {}, res: TypedResponse<{ response: string }>) =>

--- a/src/app.ts
+++ b/src/app.ts
@@ -4,6 +4,7 @@ import type { TypedRequestBody, TypedResponse } from "./types/interfaces";
 import routerOhlcv from "./controllers/ohlcv";
 import { initServer } from "./utils/server";
 import cors from "cors";
+import { routerCache } from "./controllers/cache";
 
 //initialize server, accepts no args
 
@@ -23,6 +24,7 @@ app.get("/", (req: {}, res: TypedResponse<{ response: string }>) =>
 
 //Routes
 app.use("/api/ohlcv", routerOhlcv);
+app.use("/cache", routerCache)
 
 const port = process.env.PORT || 8080;
 

--- a/src/controllers/cache.ts
+++ b/src/controllers/cache.ts
@@ -8,7 +8,7 @@ export const routerCache = express.Router();
 
 
 routerCache.post(
-  "/",
+  "",
   async (
     req: TypedRequestBody<Request>,
     res: TypedResponse<any>,

--- a/src/controllers/cache.ts
+++ b/src/controllers/cache.ts
@@ -1,0 +1,20 @@
+
+import { TypedRequestBody, TypedResponse } from "../types/interfaces";
+const express = require("express");
+
+//router for cache routes 
+export const routerCache = express.Router();
+
+
+
+routerCache.post(
+  "/",
+  async (
+    req: TypedRequestBody<Request>,
+    res: TypedResponse<any>,
+    err: Error
+  ) => {
+    console.log(req.body)
+    res.send(req.body)
+  }
+);


### PR DESCRIPTION
simple post route that returns req.body to client for cacheing, also could be tied into db or used for analytics.